### PR TITLE
Make "no command" test more flexible

### DIFF
--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -266,7 +266,7 @@ describe Docker::Image do
         subject { described_class.create('fromImage' => 'swipely/base') }
         it 'should raise an error if no command is specified' do
           expect { container }.to raise_error(
-            Docker::Error::ClientError,
+            Docker::Error::DockerError,
             /No\ command\ specified/
           )
         end
@@ -280,7 +280,7 @@ describe Docker::Image do
         subject { described_class.create('fromImage' => 'swipely/base') }
         it 'should raise an error if no command is specified' do
           expect { container }.to raise_error(
-            Docker::Error::ServerError,
+            Docker::Error::DockerError,
             /No\ command\ specified/
           )
         end


### PR DESCRIPTION
The Docker API changed the response from 500 to 400. To support a range
of Docker versions for this test, keep the message matcher the same but
make the error class more permissive.

Fixes #5.