### PR TITLE
File not exists, allow variation in error class

### DIFF
--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -277,7 +277,7 @@ describe Docker::Container do
       it 'raises an error' do
         expect { subject.copy('/lol/not/a/real/file') { |chunk| puts chunk } }
           .to raise_error(
-            Docker::Error::ServerError,
+            Docker::Error::DockerError,
             %r{Could not find the file /lol/not/a/real/file in container}
           )
       end


### PR DESCRIPTION
Variations in the Docker API between versions changed the response to
this test case to 404. Allow variation so the test case works across
versions.

Fixes #7 