### PR TITLE
Repair the test for invalid Dockerfile

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -262,8 +262,8 @@ class Docker::Image
         :response_block => response_block(body, &block)
       )
       new(connection, 'id' => Docker::Util.extract_id(body))
-    rescue Docker::Error::ServerError
-      raise Docker::Error::UnexpectedResponseError
+    rescue Docker::Error::ServerError => ex
+      raise Docker::Error::UnexpectedResponseError, ex.message
     end
 
     # Given File like object containing a tar file, builds an Image.

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -655,7 +655,8 @@ describe Docker::Image do
     context 'with an invalid Dockerfile' do
       it 'throws a UnexpectedResponseError' do
         expect { subject.build('lololol') }
-            .to raise_error(Docker::Error::UnexpectedResponseError)
+            .to raise_error(Docker::Error::DockerError,
+              /[uU]nknown instruction: LOLOLOL/)
       end
     end
 


### PR DESCRIPTION
Some version of the Docker engine changed the response for an invalid
Dockerfile, breaking this test by changing the error type, and comparing
to the message instead.

Makes a small functional change by adding a message to an exception that
previously had none.

Fixes #6.