### PR TITLE
Fixes for CPU Share specs

### DIFF
--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -206,10 +206,10 @@ describe Docker::Container do
 
     it "updates the container" do
       subject.refresh!
-      expect(subject.info.fetch("Config").fetch("CpuShares")).to eq 60000
+      expect(subject.info.fetch("HostConfig").fetch("CpuShares")).to eq 60000
       subject.update("CpuShares" => 50000)
       subject.refresh!
-      expect(subject.info.fetch("Config").fetch("CpuShares")).to eq 50000
+      expect(subject.info.fetch("HostConfig").fetch("CpuShares")).to eq 50000
     end
   end
 

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -301,7 +301,7 @@ describe Docker::Image do
       after { container.remove }
 
       it 'returns 50' do
-        expect(container.json["Config"]["CpuShares"]).to eq 50
+        expect(container.json["HostConfig"]["CpuShares"]).to eq 50
       end
     end
   end


### PR DESCRIPTION
Seems like the docker API changed at some point and broke these specs. The spec was asserting on the right properties and values but the wrong sub-structure of the config.

Unfortunately, I can't seem to get Travis running again, so I have to rely on my local for results. So I don't know if this breaks tests for older versions.

#### Before
```
Failures:

  1) Docker::Image#run when using cpu shares returns 50
     Failure/Error: expect(container.json["Config"]["CpuShares"]).to eq 50
     
       expected: 50
            got: nil
     
       (compared using ==)
     # ./spec/docker/image_spec.rb:304:in `block (4 levels) in <top (required)>'

  2) Docker::Container#update updates the container
     Failure/Error: expect(subject.info.fetch("Config").fetch("CpuShares")).to eq 60000
     
     KeyError:
       key not found: "CpuShares"
     # ./spec/docker/container_spec.rb:209:in `fetch'
     # ./spec/docker/container_spec.rb:209:in `block (3 levels) in <top (required)>'
```