### PR TITLE
Skip unnecessary array manipulation if block given

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -30,13 +30,13 @@ module Docker::Util
   end
 
   def attach_for_tty(block, msg_stack)
+    return block if block
+
     messages = Docker::Messages.new
     lambda do |c,r,t|
       messages.stdout_messages << c
       messages.all_messages << c
       msg_stack.append(messages)
-
-      block.call c if block
     end
   end
 


### PR DESCRIPTION
When handling large volumes of process output from an exec, unreasonable amounts of memory and CPU are used to process the multiplexed channels.

Much of this is used for array manipulation, which is not necessary in our use case.

This change significantly improves performance by skipping the unwanted array manipulation for attach, when a block is provided. Instead of storing the messages, it returns the message only to the block handler.