### PR TITLE
Changes to URI gem cause parsing of Unix socket URI to be different

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -17,7 +17,7 @@ class Docker::Connection
     else
       uri = URI.parse(url)
       if uri.scheme == "unix"
-        @url, @options = 'unix:///', {:socket => uri.path}.merge(opts)
+        @url, @options = 'unix:/', {:socket => uri.path}.merge(opts)
       elsif uri.scheme =~ /^(https?|tcp)$/
         @url, @options = url, opts
       else


### PR DESCRIPTION
## Before

Ruby 2.7 (uri 0.10.0.2)
```
$  ruby -ruri -e 'p URI("unix:///").host'
nil
```

Ruby 3.1 (uri 0.11.0)
```
$ ruby -ruri -e 'p URI("unix:///").host'
nil
```

Ruby 3.2 (uri 0.12.1)
```
$ ruby -ruri -e 'p URI("unix:///").host'
""
```

## After

Ruby 2.7 (uri 0.10.0.2)
```
$ ruby -ruri -e 'p URI("unix:/").host'
nil
```

Ruby 3.1 (uri 0.11.0)
```
$ ruby -ruri -e 'p URI("unix:/").host'
nil
```

Ruby 3.2 (uri 0.12.1)
```
$ ruby -ruri -e 'p URI("unix:/").host'
nil
```