### PR TITLE
No connection required when updating with authentication

### DIFF
--- a/lib/docker/service.rb
+++ b/lib/docker/service.rb
@@ -48,14 +48,14 @@ class Docker::Service
     connection.post("/services/#{self.id}/update", query, body: opts.to_json)
   end
 
-  def update_with_authentication(opts = {}, creds = nil, conn = Docker.connection)
+  def update_with_authentication(opts = {}, creds = nil, _conn = nil)
     query = {
       version:  info.dig("Version", "Index")
     }
 
     credentials = creds || Docker.creds || {}
     headers = Docker::Util.build_auth_header(credentials)
-    conn.post("/services/#{self.id}/update", query, :body => opts.to_json, :headers => headers)
+    connection.post("/services/#{self.id}/update", query, :body => opts.to_json, :headers => headers)
   end
 
   def logs(opts = {})


### PR DESCRIPTION
The connection used to request service can be re-used with auth headers. The argument is left in place with a default of `nil` to preserve the method signature.